### PR TITLE
Add interoperability

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ baseurl: "/cti-documentation" # the subpath of your site, e.g. /blog
 url: "https://oasis-open.github.io" # the base hostname & protocol for your site
 # DO NOT MODIFY THE `last_updated` date. It should be updated automatically
 # by the git pre-push hook.
-last_updated: "Tue Aug 2 22:18:01 UTC 2022"
+last_updated: "Tue Aug 02 21:20:30 UTC 2022"
 copyright: "Copyright &copy; 2017-2022, OASIS Open"
 
 # Build settings

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ baseurl: "/cti-documentation" # the subpath of your site, e.g. /blog
 url: "https://oasis-open.github.io" # the base hostname & protocol for your site
 # DO NOT MODIFY THE `last_updated` date. It should be updated automatically
 # by the git pre-push hook.
-last_updated: "Wed Jul 13 19:21:01 UTC 2022"
+last_updated: "Tue Aug 2 22:18:01 UTC 2022"
 copyright: "Copyright &copy; 2017-2022, OASIS Open"
 
 # Build settings

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ url: "https://oasis-open.github.io" # the base hostname & protocol for your site
 # DO NOT MODIFY THE `last_updated` date. It should be updated automatically
 # by the git pre-push hook.
 last_updated: "Wed Jul 13 19:21:01 UTC 2022"
-copyright: "Copyright &copy; 2017-2021, OASIS Open"
+copyright: "Copyright &copy; 2017-2022, OASIS Open"
 
 # Build settings
 markdown: kramdown

--- a/resources.md
+++ b/resources.md
@@ -41,7 +41,10 @@ Note: This version of the specification is no longer a multipart document. Older
 
 #### STIX/TAXII 2.1 Interoperability Documents
 
-**These documents are currently in progress.**
+| HTML | PDF | Word | Description |
+| --- | --- | --- | --- |
+| [**TAXII 2.1 Interoperability Test Document Version 1.0**](https://docs.oasis-open.org/cti/taxii-2.1-interop/v1.0/taxii-2.1-interop-v1.0.html) | [**TAXII 2.1 Interoperability Test Document Version 1.0**](https://docs.oasis-open.org/cti/taxii-2.1-interop/v1.0/taxii-2.1-interop-v1.0.pdf) | [**TAXII 2.1 Interoperability Test Document Version 1.0**](https://docs.oasis-open.org/cti/taxii-2.1-interop/v1.0/taxii-2.1-interop-v1.0.docx) | This document provides detailed requirements on how product implementers within the threat intelligence ecosystem may demonstrate TAXII 2.1 interoperability compliance. |
+| [**STIX 2.1 Interoperability Test Document Version 1.0**](https://docs.oasis-open.org/cti/stix-2.1-interop/v1.0/stix-2.1-interop-v1.0.html) | [**STIX 2.1 Interoperability Test Document Version 1.0**](https://docs.oasis-open.org/cti/stix-2.1-interop/v1.0/stix-2.1-interop-v1.0.pdf) | [**STIX 2.1 Interoperability Test Document Version 1.0**](https://docs.oasis-open.org/cti/stix-2.1-interop/v1.0/stix-2.1-interop-v1.0.docx) | This document provides detailed requirements on how producers of products within the threat intelligence ecosystem may demonstrate STIX 2.1 interoperability compliance.  |
 
   </div>
   <div role="tabpanel" class="tab-pane" id="v20" markdown="1">


### PR DESCRIPTION
The last_updated change was done to drive the pre-push commit hook, which I failed to configure before the previous push. This merge adds the interoperability documents to the website and fixes #39 (which was about the STIX/TAXII 2.0 Interoperability documents).
