### PR TITLE
Add extensions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ baseurl: "/cti-documentation" # the subpath of your site, e.g. /blog
 url: "https://oasis-open.github.io" # the base hostname & protocol for your site
 # DO NOT MODIFY THE `last_updated` date. It should be updated automatically
 # by the git pre-push hook.
-last_updated: "Tue Jul 11 16:31:17 UTC 2023"
+last_updated: "Tue Jul 25 22:51:19 UTC 2023"
 copyright: "Copyright &copy; 2017-2023, OASIS Open"
 
 # Build settings

--- a/resources.md
+++ b/resources.md
@@ -76,6 +76,16 @@ Note: This version of the specification is no longer a multipart document. Older
 </div>
 </div>
 
+### STIX Extensions
+{: .table .table-hover .table-example .table-desc .table-col1-width}
+| :------: | ----------- |
+| [**Incident**](https://github.com/oasis-open/cti-stix-common-objects/blob/main/extension-definition-specifications/incident-core/Incident%20Extension%20Suite.adoc){: target="_blank"} | Objects to allow tracking an incident across its lifecycle |
+| [**TLP 2.0**](https://github.com/oasis-open/cti-stix-common-objects/tree/main/extension-definition-specifications/tlp-2.0){: target="_blank"} | Enable the ability to apply TLP 2.0 markings |
+| [**Malware Artifact**](https://github.com/oasis-open/cti-stix-common-objects/tree/main/extension-definition-specifications/malware-artifact){: target="_blank"} | Enable the capture of malware artifacts |
+
+Please submit a pull request or an issue to the [cti-documentation](https://github.com/oasis-open/cti-documentation){: target="_blank"} project, if you would like to have your open extension listed here.
+
+
 ### OASIS CTI TC [Open Repositories](https://www.oasis-open.org/resources/open-repositories/){: target="_blank"}
 
 {: .table .table-hover .table-example .table-desc .table-col1-width}


### PR DESCRIPTION
Add a list of notable extensions to the CTI Documentation site. This list includes standard track and open extensions.
